### PR TITLE
Add support for the meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,18 @@
+project('sfml-game-engine', 'cpp', default_options: ['cpp_std=c++20'])
+
+sfml2_deps = [
+  dependency('sfml-graphics'),
+  dependency('sfml-system'),
+  dependency('sfml-window'),
+  dependency('sfml-audio')]
+
+executable(
+  'app',
+  'main.cpp',
+  'src/sound-manager.cpp',
+  'src/engine.cpp',
+  'src/scene.cpp',
+  'src/element.cpp',
+  'src/balloon.cpp',
+  'src/button.cpp',
+  dependencies : sfml2_deps)


### PR DESCRIPTION
# Why meson?

In my opinion the biggest reason to use meson over cmake or plain makefiles is the fact that meson's build scripts are a lot more user friendly and readable than basically any other buildsystem's files are. [Meson's homepage](https://mesonbuild.com/index.html)

# Performance

On linux meson doesn't even have support for make as a backend (for a good reason), instead it can only generate build files for ninja [Introduction to ninja](https://ninja-build.org/manual.html#_introduction). Ninja is a lot faster than make in incremental builds (changing a single file and recompiling) and meson also happens to be faster than cmake [Comparison](https://mesonbuild.com/Simple-comparison.html).

Although the performance differences only start to get more apparent in projects with hundreds of source files.

# Bloat

Cmake alone is about 240k lines of c++ code while meson is 50k of python code and ninja 20k of c++. So meson + ninja is a third of cmake's size (cmake bad)... Of course meson is yet another dependency for the project but i would argue that it doesn't matter since its available pretty much everywhere in the linux world with ninja.

# How to use

`meson setup build` Makes a new folder 'build' and generates the ninja build file and other needed files there.
`ninja -C build` or `meson compile -C build` Compile the project while using 'build' as the work directory (these commands are identical as far as i understand) oh and they both use all of your threads automatically.